### PR TITLE
Fixes #4432

### DIFF
--- a/src/Codeception/Command/Run.php
+++ b/src/Codeception/Command/Run.php
@@ -323,6 +323,12 @@ class Run extends Command
                     $config = Configuration::config($projectDir);
                 }
             } elseif (!empty($suite)) {
+                // Workaround when codeception.yml is inside tests directory and tests path is set to "."
+                // @see https://github.com/Codeception/Codeception/issues/4432
+                if ($config['paths']['tests'] === '.' && !preg_match('~^\.[/\\\]~', $suite)) {
+                    $suite = './' . $suite;
+                }
+                
                 // Run single test without included tests
                 if (! Configuration::isEmpty() && strpos($suite, $config['paths']['tests']) === 0) {
                     list(, $suite, $test) = $this->matchTestFromFilename($suite, $config['paths']['tests']);


### PR DESCRIPTION
Apply a workaround to fix #4432.

This allows having codeception.yml inside the tests directory by setting `paths`: `tests: .`

Fixing this issue properly requires a lot more work. The current CodeCeption implementation uses only basic string matching and does not expect "empty" tests path in multiple places. See for example Run->matchTestFromFilename() and Configuration::isEmpty()